### PR TITLE
Add preemphasis option to spectrograms

### DIFF
--- a/mt3/spectrograms.py
+++ b/mt3/spectrograms.py
@@ -23,6 +23,7 @@ import tensorflow as tf
 DEFAULT_SAMPLE_RATE = 16000
 DEFAULT_HOP_WIDTH = 128
 DEFAULT_NUM_MEL_BINS = 512
+DEFAULT_PREEMPHASIS = 0.0
 
 # fixed constants; add these to SpectrogramConfig before changing
 FFT_SIZE = 2048
@@ -35,6 +36,7 @@ class SpectrogramConfig:
   sample_rate: int = DEFAULT_SAMPLE_RATE
   hop_width: int = DEFAULT_HOP_WIDTH
   num_mel_bins: int = DEFAULT_NUM_MEL_BINS
+  preemphasis: float = DEFAULT_PREEMPHASIS
 
   @property
   def abbrev_str(self):
@@ -45,6 +47,8 @@ class SpectrogramConfig:
       s += 'hw%d' % self.hop_width
     if self.num_mel_bins != DEFAULT_NUM_MEL_BINS:
       s += 'mb%d' % self.num_mel_bins
+    if self.preemphasis != DEFAULT_PREEMPHASIS:
+      s += 'pe%d' % round(self.preemphasis * 100)
     return s
 
   @property
@@ -63,6 +67,12 @@ def split_audio(samples, spectrogram_config):
 
 def compute_spectrogram(samples, spectrogram_config):
   """Compute a mel spectrogram."""
+  if spectrogram_config.preemphasis:
+    samples = tf.concat([
+        samples[:1],
+        samples[1:] - spectrogram_config.preemphasis * samples[:-1]
+    ],
+                       axis=0)
   overlap = 1 - (spectrogram_config.hop_width / FFT_SIZE)
   return spectral_ops.compute_logmel(
       samples,

--- a/mt3/spectrograms_test.py
+++ b/mt3/spectrograms_test.py
@@ -1,0 +1,30 @@
+from unittest import mock
+from absl.testing import absltest
+import tensorflow as tf
+
+from mt3 import spectral_ops
+from mt3 import spectrograms
+
+
+class SpectrogramsTest(absltest.TestCase):
+
+  def test_preemphasis_applied(self):
+    samples = tf.constant([1.0, 2.0, 3.0], dtype=tf.float32)
+    cfg = spectrograms.SpectrogramConfig(
+        sample_rate=1,
+        hop_width=1,
+        num_mel_bins=1,
+        preemphasis=0.5)
+
+    with mock.patch.object(spectral_ops, 'compute_logmel',
+                           return_value=tf.zeros([1, 1], tf.float32)) as mock_fn:
+      spectrograms.compute_spectrogram(samples, cfg)
+      mock_fn.assert_called_once()
+      called_samples = mock_fn.call_args.args[0]
+      expected = tf.constant([1.0, 2.0 - 0.5 * 1.0, 3.0 - 0.5 * 2.0],
+                             dtype=tf.float32)
+      tf.debugging.assert_near(expected, called_samples)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary
- support optional pre-emphasis when computing spectrograms
- expose pre-emphasis factor in SpectrogramConfig
- test that pre-emphasis is applied

## Testing
- `pytest mt3/spectrograms_test.py -q` *(fails: ModuleNotFoundError: No module named 'seqio')*

------
https://chatgpt.com/codex/tasks/task_e_6840ad8901148324ae52876f2467e873